### PR TITLE
fix: resolve skill paths from loaded SKILL.md (#27)

### DIFF
--- a/harmony-next/ISSUE_GUIDE.md
+++ b/harmony-next/ISSUE_GUIDE.md
@@ -21,18 +21,18 @@ Choose the issue form that matches the workflow under investigation:
 ## Workflow
 
 1. Clarify only the minimum missing detail needed to avoid filing a wrong issue.
-2. Reproduce or inspect locally when possible. Prefer machine-readable checks from this skill:
-   - `python3 harmony-next/scripts/hvd_manager.py doctor --json`
-   - `python3 harmony-next/scripts/hvd_manager.py list --json`
-   - `python3 harmony-next/scripts/hvd_manager.py launch-preflight ... --json`
-   - `python3 harmony-next/scripts/hvd_manager.py launch ... --json`
-   - `python3 harmony-next/scripts/commandline_tools_manager.py doctor --tools-root <dir> --json`
-   - `python3 harmony-next/scripts/device_evidence_bundle.py doctor --deveco-app <DevEco-Studio.app> --json`
-   - `python3 harmony-next/scripts/device_evidence_bundle.py webview-devtools --deveco-app <DevEco-Studio.app> --target <target> --artifact-dir <dir> --json`
-   - `python3 harmony-next/scripts/device_ui_action.py tap --deveco-app <DevEco-Studio.app> --target <target> --artifact-dir <dir> --text "<text>" --json`
-   - `python3 harmony-next/scripts/ux_audit_pipeline.py doctor --deveco-app <DevEco-Studio.app> --python <python-with-ux-deps> --json`
-   - `python3 harmony-next/scripts/reference_compat.py check`
-   - `python3 -m unittest discover -s harmony-next/tests`
+2. Reproduce or inspect locally when possible. Prefer machine-readable checks from this skill. Resolve `HARMONY_NEXT_SKILL_DIR` from the loaded `SKILL.md` first; do not assume `harmony-next/` exists at the current repository root:
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" doctor --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" list --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" launch-preflight ... --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" launch ... --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/commandline_tools_manager.py" doctor --tools-root <dir> --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_evidence_bundle.py" doctor --deveco-app <DevEco-Studio.app> --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_evidence_bundle.py" webview-devtools --deveco-app <DevEco-Studio.app> --target <target> --artifact-dir <dir> --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_ui_action.py" tap --deveco-app <DevEco-Studio.app> --target <target> --artifact-dir <dir> --text "<text>" --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/ux_audit_pipeline.py" doctor --deveco-app <DevEco-Studio.app> --python <python-with-ux-deps> --json`
+   - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/reference_compat.py" check`
+   - `python3 -m unittest discover -s "$HARMONY_NEXT_SKILL_DIR/tests"`
 3. Preserve structured fields in the issue instead of flattening them into prose:
    - `decision`
    - `operation`

--- a/harmony-next/ISSUE_GUIDE.md
+++ b/harmony-next/ISSUE_GUIDE.md
@@ -32,7 +32,7 @@ Choose the issue form that matches the workflow under investigation:
    - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_ui_action.py" tap --deveco-app <DevEco-Studio.app> --target <target> --artifact-dir <dir> --text "<text>" --json`
    - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/ux_audit_pipeline.py" doctor --deveco-app <DevEco-Studio.app> --python <python-with-ux-deps> --json`
    - `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/reference_compat.py" check`
-   - `python3 -m unittest discover -s "$HARMONY_NEXT_SKILL_DIR/tests"`
+   - Source checkout only, when `$HARMONY_NEXT_SKILL_DIR/tests` exists: `python3 -m unittest discover -s "$HARMONY_NEXT_SKILL_DIR/tests"`
 3. Preserve structured fields in the issue instead of flattening them into prose:
    - `decision`
    - `operation`

--- a/harmony-next/SKILL.md
+++ b/harmony-next/SKILL.md
@@ -16,7 +16,7 @@ Paths like `references/...` and `scripts/...` are relative to this skill directo
 HARMONY_NEXT_SKILL_DIR="<skill-dir>"
 ```
 
-Use `$HARMONY_NEXT_SKILL_DIR` from any working directory, including a normal application repository root. Bundled playbooks must use this variable for executable paths; treat a literal `harmony-next/references/...` or `python3 harmony-next/scripts/...` command in a bundled playbook as a portability bug.
+Use `$HARMONY_NEXT_SKILL_DIR` from any working directory, including a normal application repository root. Bundled playbooks must use this variable for executable paths; treat any hard-coded repository-root skill prefix in a bundled playbook as a portability bug.
 
 ## Version
 

--- a/harmony-next/SKILL.md
+++ b/harmony-next/SKILL.md
@@ -9,7 +9,14 @@ metadata:
 
 Use this skill to answer HarmonyOS NEXT questions with the bundled offline references. Keep context small: route the request first, then open only the specific Markdown files needed for the answer or action.
 
-Paths like `references/...` are relative to this skill directory (`harmony-next/`). If your current working directory is the repository root, either `cd harmony-next` first or prefix paths with `harmony-next/`.
+Paths like `references/...` and `scripts/...` are relative to this skill directory: the directory that contains this `SKILL.md`. Resolve that directory once as `HARMONY_NEXT_SKILL_DIR`. Do not assume `harmony-next/` exists at the current repository root. Official scan locations include `$REPO_ROOT/.agents/skills/harmony-next`, `$HOME/.agents/skills/harmony-next`, and `/etc/codex/skills/harmony-next`.
+
+```bash
+# Directory containing this SKILL.md (the file you loaded).
+HARMONY_NEXT_SKILL_DIR="<skill-dir>"
+```
+
+Use `$HARMONY_NEXT_SKILL_DIR` from any working directory, including a normal application repository root. If a later playbook still shows `harmony-next/references/...` or `python3 harmony-next/scripts/...`, rewrite that prefix to `$HARMONY_NEXT_SKILL_DIR`.
 
 ## Version
 
@@ -51,13 +58,11 @@ Install/update entrypoints:
 
 ## Lookup Commands
 
-From the skill directory:
+After resolving `HARMONY_NEXT_SKILL_DIR` from this `SKILL.md`:
 
-- 先按关键词命中路径：`rg -n "UIAbility|AbilityStage|Want" references/INDEX.md | head`
-- 查某个 `@ohos.*` 模块：`rg -n "@ohos\\.app\\.ability\\.|@ohos\\.ability\\." references/INDEX.md | rg "JsEtsAPIReference/" | head`
-- 查 NDK/C API 头文件：`rg -n "JsEtsAPIReference/topics/.*/.*\\.h\\.md$" references/INDEX.md | rg "(napi|arkui|window|ability)" | head`
-
-From the repository root, use `harmony-next/references/...` in the same commands.
+- 先按关键词命中路径：`rg -n "UIAbility|AbilityStage|Want" "$HARMONY_NEXT_SKILL_DIR/references/INDEX.md" | head`
+- 查某个 `@ohos.*` 模块：`rg -n "@ohos\\.app\\.ability\\.|@ohos\\.ability\\." "$HARMONY_NEXT_SKILL_DIR/references/INDEX.md" | rg "JsEtsAPIReference/" | head`
+- 查 NDK/C API 头文件：`rg -n "JsEtsAPIReference/topics/.*/.*\\.h\\.md$" "$HARMONY_NEXT_SKILL_DIR/references/INDEX.md" | rg "(napi|arkui|window|ability)" | head`
 
 ## Tooling Script Skills
 
@@ -65,12 +70,12 @@ Use these script-backed skill entries before hand-writing DevEco setup commands.
 
 | User intent | Script skill | Agent first command | User handoff |
 | --- | --- | --- | --- |
-| Download, install, configure, or validate HarmonyOS Command Line Tools | `commandline_tools_manager.py` | `python3 harmony-next/scripts/commandline_tools_manager.py doctor --tools-root <dir> --json` | If the user gives a Huawei download center page URL, return the script's blocked result and ask the user to log in, copy the direct archive URL, or provide a local archive. |
-| List, clone, delete, diagnose, or launch local DevEco HVD instances | `hvd_manager.py` | `python3 harmony-next/scripts/hvd_manager.py doctor --json` | If HVD root, Emulator, SDK/image root, or trace startup data is missing, report the `issues`, `recommendations`, and `missingConfig` fields and ask the user to pass `--root`, `--emulator`, `--sdk-root` / `--image-root`, or matching env vars. |
-| Collect bounded HDC device evidence or diagnose WebView DevTools forwarding | `device_evidence_bundle.py` | `python3 harmony-next/scripts/device_evidence_bundle.py doctor --deveco-app <DevEco-Studio.app> --json` | Use `capture ... --artifact-dir <dir>` only when raw local screenshots, layout trees, app state, and bounded logs may be stored locally. Use `webview-devtools ... --artifact-dir <dir>` for socket/fport/HTTP discovery classification. |
-| Perform one bounded UI action with before/after evidence | `device_ui_action.py` | `python3 harmony-next/scripts/device_ui_action.py tap --deveco-app <DevEco-Studio.app> --target <target> --artifact-dir .hvigor/outputs/<run> --text "<visible-text>" --json` | Require exactly one target selector or raw device coordinate. Treat returned screenshot dimensions as the coordinate space; never reuse scaled preview coordinates. |
-| Capture a running HarmonyOS page and run an offline UI/UX audit report | `ux_audit_pipeline.py` | `python3 harmony-next/scripts/ux_audit_pipeline.py doctor --deveco-app <DevEco-Studio.app> --python <python-with-ux-deps> --json` | Use `python3 harmony-next/scripts/ux_audit_pipeline.py capture-audit --deveco-app <DevEco-Studio.app> --python <python-with-ux-deps> --target <target> --artifact-dir .hvigor/outputs/<run> --json` for the one-shot path. If Python image-processing modules are missing, report `missingConfig=["uxPythonDependencies"]` instead of treating UxTestService as broken. |
-| Convert offline DevEco Profiler trace files into SQLite evidence summaries | `profiler_trace_audit.py` | `python3 harmony-next/scripts/profiler_trace_audit.py doctor --deveco-app <DevEco-Studio.app> --json` | If `trace_streamer` or the input trace is missing, report the machine-readable `blocked` payload. Use `audit --input <trace> --output-dir .hvigor/outputs/<run> --json` only for existing `.ftrace` / `.htrace` / bytrace / rawtrace artifacts. |
+| Download, install, configure, or validate HarmonyOS Command Line Tools | `commandline_tools_manager.py` | `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/commandline_tools_manager.py" doctor --tools-root <dir> --json` | If the user gives a Huawei download center page URL, return the script's blocked result and ask the user to log in, copy the direct archive URL, or provide a local archive. |
+| List, clone, delete, diagnose, or launch local DevEco HVD instances | `hvd_manager.py` | `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" doctor --json` | If HVD root, Emulator, SDK/image root, or trace startup data is missing, report the `issues`, `recommendations`, and `missingConfig` fields and ask the user to pass `--root`, `--emulator`, `--sdk-root` / `--image-root`, or matching env vars. |
+| Collect bounded HDC device evidence or diagnose WebView DevTools forwarding | `device_evidence_bundle.py` | `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_evidence_bundle.py" doctor --deveco-app <DevEco-Studio.app> --json` | Use `capture ... --artifact-dir <dir>` only when raw local screenshots, layout trees, app state, and bounded logs may be stored locally. Use `webview-devtools ... --artifact-dir <dir>` for socket/fport/HTTP discovery classification. |
+| Perform one bounded UI action with before/after evidence | `device_ui_action.py` | `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_ui_action.py" tap --deveco-app <DevEco-Studio.app> --target <target> --artifact-dir .hvigor/outputs/<run> --text "<visible-text>" --json` | Require exactly one target selector or raw device coordinate. Treat returned screenshot dimensions as the coordinate space; never reuse scaled preview coordinates. |
+| Capture a running HarmonyOS page and run an offline UI/UX audit report | `ux_audit_pipeline.py` | `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/ux_audit_pipeline.py" doctor --deveco-app <DevEco-Studio.app> --python <python-with-ux-deps> --json` | Use `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/ux_audit_pipeline.py" capture-audit --deveco-app <DevEco-Studio.app> --python <python-with-ux-deps> --target <target> --artifact-dir .hvigor/outputs/<run> --json` for the one-shot path. If Python image-processing modules are missing, report `missingConfig=["uxPythonDependencies"]` instead of treating UxTestService as broken. |
+| Convert offline DevEco Profiler trace files into SQLite evidence summaries | `profiler_trace_audit.py` | `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/profiler_trace_audit.py" doctor --deveco-app <DevEco-Studio.app> --json` | If `trace_streamer` or the input trace is missing, report the machine-readable `blocked` payload. Use `audit --input <trace> --output-dir .hvigor/outputs/<run> --json` only for existing `.ftrace` / `.htrace` / bytrace / rawtrace artifacts. |
 
 Boundaries:
 

--- a/harmony-next/SKILL.md
+++ b/harmony-next/SKILL.md
@@ -16,7 +16,7 @@ Paths like `references/...` and `scripts/...` are relative to this skill directo
 HARMONY_NEXT_SKILL_DIR="<skill-dir>"
 ```
 
-Use `$HARMONY_NEXT_SKILL_DIR` from any working directory, including a normal application repository root. If a later playbook still shows `harmony-next/references/...` or `python3 harmony-next/scripts/...`, rewrite that prefix to `$HARMONY_NEXT_SKILL_DIR`.
+Use `$HARMONY_NEXT_SKILL_DIR` from any working directory, including a normal application repository root. Bundled playbooks must use this variable for executable paths; treat a literal `harmony-next/references/...` or `python3 harmony-next/scripts/...` command in a bundled playbook as a portability bug.
 
 ## Version
 

--- a/harmony-next/references/ideGuides/ArkWeb WebView CDP调试与字段到达证明.md
+++ b/harmony-next/references/ideGuides/ArkWeb WebView CDP调试与字段到达证明.md
@@ -21,7 +21,7 @@
 ## 第一步：诊断 WebView DevTools 转发
 
 ```bash
-python3 harmony-next/scripts/device_evidence_bundle.py webview-devtools \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_evidence_bundle.py" webview-devtools \
   --deveco-app /Applications/DevEco-Studio.app \
   --target <target> \
   --artifact-dir .hvigor/outputs/webview-devtools \
@@ -31,7 +31,7 @@ python3 harmony-next/scripts/device_evidence_bundle.py webview-devtools \
 多个 WebView socket 时必须显式选择：
 
 ```bash
-python3 harmony-next/scripts/device_evidence_bundle.py webview-devtools \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_evidence_bundle.py" webview-devtools \
   --deveco-app /Applications/DevEco-Studio.app \
   --target <target> \
   --remote-socket webview_devtools_remote_<pid> \

--- a/harmony-next/references/ideGuides/DevEco模拟器私有接口与AI自动化.md
+++ b/harmony-next/references/ideGuides/DevEco模拟器私有接口与AI自动化.md
@@ -198,7 +198,7 @@ wukong focus
 脚本化时先用仓库 helper 做 preflight。该命令只验证 HVD、Emulator、SDK 和 trace helper readiness，不负责创建私有 trace pipe，也不直接启动 Emulator：
 
 ```bash
-python3 harmony-next/scripts/hvd_manager.py \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" \
   --root "$HOME/.Huawei/Emulator/deployed" \
   --emulator "/Applications/DevEco-Studio.app/Contents/tools/emulator/Emulator" \
   --sdk-root "$HOME/Library/Huawei/Sdk" \
@@ -214,7 +214,7 @@ python3 harmony-next/scripts/hvd_manager.py \
 需要由仓库脚本直接执行启动时，使用 `launch`。当前实现会创建本轮启动用的有界 trace socket，detach Emulator 与 trace holder，启动 Emulator，并在默认路径下等待 HDC target；只想验证启动进程与 trace socket 连接时传 `--no-wait-target`：
 
 ```bash
-python3 harmony-next/scripts/hvd_manager.py \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" \
   --root "$HOME/.Huawei/Emulator/deployed" \
   --emulator "/Applications/DevEco-Studio.app/Contents/tools/emulator/Emulator" \
   launch \
@@ -284,13 +284,13 @@ cd "/Applications/DevEco-Studio.app/Contents/tools/emulator"
 仓库提供一个受控命令行封装：
 
 ```bash
-python3 harmony-next/scripts/hvd_manager.py list --json
-python3 harmony-next/scripts/hvd_manager.py doctor --json
-python3 harmony-next/scripts/hvd_manager.py create --from "<source-hvd>" --name "<new-hvd>" --hdc-port 10100
-python3 harmony-next/scripts/hvd_manager.py delete --name "<new-hvd>" --confirm-name "<new-hvd>"
-python3 harmony-next/scripts/hvd_manager.py launch-preflight --name "<hvd-name>" --trace-name "<trace-name>" --trace-helper-ready-file "<helper-ready-file>" --json
-python3 harmony-next/scripts/hvd_manager.py launch --name "<hvd-name>" --image-root "<sdk-image-root>" --trace-name "<trace-name>" --json
-python3 harmony-next/scripts/hvd_manager.py download-image --device-type phone --api-version 22
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" list --json
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" doctor --json
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" create --from "<source-hvd>" --name "<new-hvd>" --hdc-port 10100
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" delete --name "<new-hvd>" --confirm-name "<new-hvd>"
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" launch-preflight --name "<hvd-name>" --trace-name "<trace-name>" --trace-helper-ready-file "<helper-ready-file>" --json
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" launch --name "<hvd-name>" --image-root "<sdk-image-root>" --trace-name "<trace-name>" --json
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" download-image --device-type phone --api-version 22
 ```
 
 边界：
@@ -386,7 +386,7 @@ python3 harmony-next/scripts/hvd_manager.py download-image --device-type phone -
 当目标是 ArkWeb/H5 bridge 字段到达证明时，先阅读 `ArkWeb WebView CDP调试与字段到达证明.md`。不要用项目私有转发脚本或全局 HDC 重启替代结构化诊断。
 
 ```bash
-python3 harmony-next/scripts/device_evidence_bundle.py webview-devtools \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/device_evidence_bundle.py" webview-devtools \
   --deveco-app /Applications/DevEco-Studio.app \
   --target <target> \
   --artifact-dir .hvigor/outputs/webview-devtools \

--- a/harmony-next/references/ideGuides/命令行工具指南.md
+++ b/harmony-next/references/ideGuides/命令行工具指南.md
@@ -8,7 +8,7 @@ HarmonyOS 命令行工具（Command Line Tools）支持脱离 IDE 进行自动�
 ### 获取方式
 *   **DevEco Studio 内部获取**：`Settings > SDK > Tools` 勾选 `Command Line Tools` 下载。
 *   **独立获取**：从华为开发者联盟官网下载独立软件包。
-*   **脚本封装**：仓库内 `python3 harmony-next/scripts/commandline_tools_manager.py` 支持下载中心压缩包直链下载、本地 archive 安装、profile 配置和 `doctor` 校验。
+*   **脚本封装**：skill 内 `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/commandline_tools_manager.py"` 支持下载中心压缩包直链下载、本地 archive 安装、profile 配置和 `doctor` 校验。
 
 ### 环境变量配置
 为了在全局使用命令行，需将 `bin` 目录添加到系统 PATH：
@@ -25,7 +25,7 @@ export PATH=$PATH:/path/to/ohpm/bin
 脚本示例：
 
 ```bash
-python3 harmony-next/scripts/commandline_tools_manager.py install \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/commandline_tools_manager.py" install \
   --archive "/path/to/command-line-tools.zip" \
   --dest "$HOME/.harmony/command-line-tools" \
   --profile auto \
@@ -77,7 +77,7 @@ python3 harmony-next/scripts/commandline_tools_manager.py install \
 *   `Emulator -version` / `-help`: 查看版本或完整帮助文档。
 *   `Emulator -logZip [Name] -logPath [ZipPath]`: 收集模拟器日志并打包。
 *   **注意**：官方 `Emulator` 命令未验证到稳定的新建实例入口；仓库封装的 `hvd_manager.py create` 只能基于本地已有同版本实例做受控克隆，并会刷新名称、路径、UUID 和可选 HDC 端口。
-*   **环境自检**：分发给其他机器前，先运行 `python3 harmony-next/scripts/hvd_manager.py doctor --json`，再根据输出补 `--root`、`--emulator`、`--sdk-root` 或对应环境变量。
+*   **环境自检**：分发给其他机器前，先运行 `python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" doctor --json`，再根据输出补 `--root`、`--emulator`、`--sdk-root` 或对应环境变量。
 
 #### 实操案例：macOS 环境下查找与启动模拟器
 如果你在终端直接输入 `Emulator` 提示找不到命令，可以按照以下实操流程进行：

--- a/harmony-next/references/ideGuides/独立命令行工具配置手册.md
+++ b/harmony-next/references/ideGuides/独立命令行工具配置手册.md
@@ -15,21 +15,21 @@
 
 ```bash
 # 使用下载中心复制出的压缩包直链，一步下载、安装和配置 PATH
-python3 harmony-next/scripts/commandline_tools_manager.py bootstrap \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/commandline_tools_manager.py" bootstrap \
   --url "<direct-command-line-tools-archive-url>" \
   --dest "$HOME/.harmony/command-line-tools" \
   --profile auto \
   --sha256 "<sha256-from-download-center>"
 
 # 已经手动下载压缩包时，直接安装和配置
-python3 harmony-next/scripts/commandline_tools_manager.py install \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/commandline_tools_manager.py" install \
   --archive "/path/to/command-line-tools.zip" \
   --dest "$HOME/.harmony/command-line-tools" \
   --profile auto \
   --sha256 "<sha256-from-download-center>"
 
 # 校验布局和 codelinter 版本
-python3 harmony-next/scripts/commandline_tools_manager.py doctor \
+python3 "$HARMONY_NEXT_SKILL_DIR/scripts/commandline_tools_manager.py" doctor \
   --tools-root "$HOME/.harmony/command-line-tools"
 ```
 

--- a/harmony-next/references/quickStart/ets/minimal-project-scaffold.md
+++ b/harmony-next/references/quickStart/ets/minimal-project-scaffold.md
@@ -3,7 +3,7 @@
 当 agent 需要在任意仓库内生成 HarmonyOS NEXT 测试工程，但不能打开 DevEco Studio 向导时，优先复制本仓库模板：
 
 ```bash
-cp -R harmony-next/references/templates/empty-ability-app <target-repo>/harmony-empty-ability
+cp -R "$HARMONY_NEXT_SKILL_DIR/references/templates/empty-ability-app" <target-repo>/harmony-empty-ability
 ```
 
 模板入口：

--- a/harmony-next/scripts/device_evidence_bundle.py
+++ b/harmony-next/scripts/device_evidence_bundle.py
@@ -26,7 +26,7 @@ REMOTE_TMP_ROOT = "/data/local/tmp"
 FEEDBACK_REPOSITORY = "linhay/harmony-next.skills"
 FEEDBACK_ISSUE_TEMPLATE = "device-evidence-bundle.yml"
 FEEDBACK_ISSUE_URL = f"https://github.com/{FEEDBACK_REPOSITORY}/issues/new?template={FEEDBACK_ISSUE_TEMPLATE}"
-FEEDBACK_ISSUE_GUIDE = "harmony-next/ISSUE_GUIDE.md"
+FEEDBACK_ISSUE_GUIDE = "$HARMONY_NEXT_SKILL_DIR/ISSUE_GUIDE.md"
 OFFICIAL_CLI_FALLBACK_RECOMMENDATIONS = [
     "If this wrapper is blocked, agents should fall back to official HarmonyOS CLI commands first.",
     "Run `hdc list targets -v` to select a target, then use `hdc -t <target> shell bm dump -g`, `hdc -t <target> shell aa dump -l`, and bounded `hdc -t <target> shell hilog -z <lines>` for state evidence.",

--- a/harmony-next/scripts/hvd_manager.py
+++ b/harmony-next/scripts/hvd_manager.py
@@ -867,7 +867,7 @@ def build_trace_timeout_diagnostics(
             "purpose": "Validate launch inputs without starting Emulator",
             "command": [
                 sys.executable,
-                "harmony-next/scripts/hvd_manager.py",
+                str(Path(__file__).resolve()),
                 "--root",
                 str(root),
                 "--emulator",

--- a/harmony-next/scripts/ux_audit_pipeline.py
+++ b/harmony-next/scripts/ux_audit_pipeline.py
@@ -40,7 +40,7 @@ SYSTEM_BUNDLE_NAMES = {
 FEEDBACK_REPOSITORY = "linhay/harmony-next.skills"
 FEEDBACK_ISSUE_TEMPLATE = "offline-ux-audit.yml"
 FEEDBACK_ISSUE_URL = f"https://github.com/{FEEDBACK_REPOSITORY}/issues/new?template={FEEDBACK_ISSUE_TEMPLATE}"
-FEEDBACK_ISSUE_GUIDE = "harmony-next/ISSUE_GUIDE.md"
+FEEDBACK_ISSUE_GUIDE = "$HARMONY_NEXT_SKILL_DIR/ISSUE_GUIDE.md"
 OFFICIAL_CLI_FALLBACK_RECOMMENDATIONS = [
     "If this wrapper is blocked, agents should fall back to official HarmonyOS CLI commands first.",
     "Start with `hdc list targets -v`, then run `hdc -t <target> shell uitest dumpLayout -p /data/local/tmp/layout.json -a` and `hdc -t <target> shell uitest screenCap -p /data/local/tmp/screen.png`.",

--- a/harmony-next/tests/test_device_evidence_bundle.py
+++ b/harmony-next/tests/test_device_evidence_bundle.py
@@ -302,7 +302,7 @@ class DeviceEvidenceBundleTests(unittest.TestCase):
         self.assertIn("target", payload["missingConfig"])
         self.assertEqual(len(payload["connectedTargets"]), 2)
         self.assertTrue(any("hdc list targets -v" in item for item in payload["recommendations"]))
-        self.assertIn("ISSUE_GUIDE.md", payload["feedback"]["issueGuide"])
+        self.assertEqual(payload["feedback"]["issueGuide"], "$HARMONY_NEXT_SKILL_DIR/ISSUE_GUIDE.md")
 
     def test_capture_blocks_when_requested_target_has_no_connected_targets(self) -> None:
         artifact_dir = self.root / "artifacts"

--- a/harmony-next/tests/test_hvd_manager.py
+++ b/harmony-next/tests/test_hvd_manager.py
@@ -888,6 +888,14 @@ class HvdManagerTests(unittest.TestCase):
         command_purposes = {item["purpose"] for item in diagnostics["nextDiagnosticCommands"]}
         self.assertIn("Inspect HVD runtime state", command_purposes)
         self.assertIn("Inspect HDC target state", command_purposes)
+        preflight_commands = [
+            item["command"]
+            for item in diagnostics["nextDiagnosticCommands"]
+            if item["purpose"] == "Validate launch inputs without starting Emulator"
+        ]
+        self.assertTrue(preflight_commands)
+        self.assertEqual(preflight_commands[0][1], str(SCRIPT_PATH))
+        self.assertNotIn("harmony-next/scripts/hvd_manager.py", preflight_commands[0])
 
     def test_launch_classifies_kernel_panic_after_hdc_timeout(self) -> None:
         emulator = Path(self.temp_dir.name) / "Emulator"

--- a/harmony-next/tests/test_skill_metadata.py
+++ b/harmony-next/tests/test_skill_metadata.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -187,12 +189,66 @@ class SkillMetadataTests(unittest.TestCase):
             shutil.copy2(SKILL_ROOT / "references" / "INDEX.md", skill_dir / "references" / "INDEX.md")
             shutil.copy2(SKILL_ROOT / "scripts" / "hvd_manager.py", skill_dir / "scripts" / "hvd_manager.py")
 
-            env = {"HARMONY_NEXT_SKILL_DIR": str(skill_dir)}
+            env = {
+                **os.environ,
+                "HARMONY_NEXT_SKILL_DIR": str(skill_dir),
+                "HARMONY_NEXT_PYTHON": sys.executable,
+            }
             self.assertFalse((repo_root / "harmony-next" / "references" / "INDEX.md").exists())
             self.assertFalse((repo_root / "harmony-next" / "scripts" / "hvd_manager.py").exists())
             self.assertTrue((Path(env["HARMONY_NEXT_SKILL_DIR"]) / "references" / "INDEX.md").is_file())
             self.assertTrue((Path(env["HARMONY_NEXT_SKILL_DIR"]) / "scripts" / "hvd_manager.py").is_file())
             self.assertTrue((Path(env["HARMONY_NEXT_SKILL_DIR"]) / "SKILL.md").is_file())
+
+            shell = shutil.which("sh")
+            self.assertIsNotNone(shell)
+            assert shell is not None
+
+            help_result = subprocess.run(
+                [
+                    shell,
+                    "-c",
+                    '"$HARMONY_NEXT_PYTHON" "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" --help',
+                ],
+                cwd=repo_root,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(help_result.returncode, 0, help_result.stderr)
+            self.assertIn("Manage local DevEco HarmonyOS HVD instances", help_result.stdout)
+
+            rg = shutil.which("rg")
+            if rg:
+                env["HARMONY_NEXT_RG"] = rg
+                lookup_result = subprocess.run(
+                    [
+                        shell,
+                        "-c",
+                        '"$HARMONY_NEXT_RG" -n "UIAbility|AbilityStage|Want" '
+                        '"$HARMONY_NEXT_SKILL_DIR/references/INDEX.md"',
+                    ],
+                    cwd=repo_root,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(lookup_result.returncode, 0, lookup_result.stderr)
+                self.assertIn("UIAbility", lookup_result.stdout)
+
+    def test_bundled_playbooks_do_not_use_repo_root_skill_commands(self) -> None:
+        forbidden_fragments = [
+            "python3 harmony-next/scripts/",
+            "cp -R harmony-next/references/",
+        ]
+
+        for path in sorted((SKILL_ROOT / "references").rglob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            for fragment in forbidden_fragments:
+                with self.subTest(path=path.relative_to(SKILL_ROOT), forbidden=fragment):
+                    self.assertNotIn(fragment, text)
 
     def test_skill_exposes_current_version_for_agents(self) -> None:
         metadata_version = re.search(r"version:\s*\"(\d+\.\d+\.\d+)\"", self.skill_text)

--- a/harmony-next/tests/test_skill_metadata.py
+++ b/harmony-next/tests/test_skill_metadata.py
@@ -157,6 +157,43 @@ class SkillMetadataTests(unittest.TestCase):
 
             self.assertEqual(find_repo_root(skill_root), repo_root)
 
+    def test_skill_resolves_paths_from_loaded_skill_md(self) -> None:
+        required_fragments = [
+            "HARMONY_NEXT_SKILL_DIR",
+            'HARMONY_NEXT_SKILL_DIR="<skill-dir>"',
+            "$HARMONY_NEXT_SKILL_DIR/references/INDEX.md",
+            'python3 "$HARMONY_NEXT_SKILL_DIR/scripts/hvd_manager.py" doctor --json',
+            "$REPO_ROOT/.agents/skills/harmony-next",
+        ]
+        forbidden_fragments = [
+            "From the repository root, use `harmony-next/references/",
+            "python3 harmony-next/scripts/hvd_manager.py",
+            "python3 harmony-next/scripts/commandline_tools_manager.py",
+        ]
+
+        for fragment in required_fragments:
+            with self.subTest(required=fragment):
+                self.assertIn(fragment, self.skill_text)
+        for fragment in forbidden_fragments:
+            with self.subTest(forbidden=fragment):
+                self.assertNotIn(fragment, self.skill_text)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            skill_dir = repo_root / ".agents" / "skills" / "harmony-next"
+            (skill_dir / "references").mkdir(parents=True)
+            (skill_dir / "scripts").mkdir(parents=True)
+            shutil.copy2(SKILL_PATH, skill_dir / "SKILL.md")
+            shutil.copy2(SKILL_ROOT / "references" / "INDEX.md", skill_dir / "references" / "INDEX.md")
+            shutil.copy2(SKILL_ROOT / "scripts" / "hvd_manager.py", skill_dir / "scripts" / "hvd_manager.py")
+
+            env = {"HARMONY_NEXT_SKILL_DIR": str(skill_dir)}
+            self.assertFalse((repo_root / "harmony-next" / "references" / "INDEX.md").exists())
+            self.assertFalse((repo_root / "harmony-next" / "scripts" / "hvd_manager.py").exists())
+            self.assertTrue((Path(env["HARMONY_NEXT_SKILL_DIR"]) / "references" / "INDEX.md").is_file())
+            self.assertTrue((Path(env["HARMONY_NEXT_SKILL_DIR"]) / "scripts" / "hvd_manager.py").is_file())
+            self.assertTrue((Path(env["HARMONY_NEXT_SKILL_DIR"]) / "SKILL.md").is_file())
+
     def test_skill_exposes_current_version_for_agents(self) -> None:
         metadata_version = re.search(r"version:\s*\"(\d+\.\d+\.\d+)\"", self.skill_text)
         visible_version = re.search(r"Current local skill version:\s*`v\d+\.\d+\.\d+`", self.skill_text)

--- a/harmony-next/tests/test_skill_metadata.py
+++ b/harmony-next/tests/test_skill_metadata.py
@@ -239,16 +239,18 @@ class SkillMetadataTests(unittest.TestCase):
                 self.assertIn("UIAbility", lookup_result.stdout)
 
     def test_bundled_playbooks_do_not_use_repo_root_skill_commands(self) -> None:
-        forbidden_fragments = [
-            "python3 harmony-next/scripts/",
-            "cp -R harmony-next/references/",
+        forbidden_patterns = [
+            re.compile(r"(?<!\$HARMONY_NEXT_SKILL_DIR/)(?:\./)?harmony-next/scripts/"),
+            re.compile(r"(?:\./)?harmony-next/references/"),
         ]
 
-        for path in sorted((SKILL_ROOT / "references").rglob("*.md")):
+        bundled_markdown = [SKILL_PATH, SKILL_ROOT / "ISSUE_GUIDE.md"]
+        bundled_markdown.extend(sorted((SKILL_ROOT / "references").rglob("*.md")))
+        for path in bundled_markdown:
             text = path.read_text(encoding="utf-8")
-            for fragment in forbidden_fragments:
-                with self.subTest(path=path.relative_to(SKILL_ROOT), forbidden=fragment):
-                    self.assertNotIn(fragment, text)
+            for pattern in forbidden_patterns:
+                with self.subTest(path=path.relative_to(SKILL_ROOT), forbidden=pattern.pattern):
+                    self.assertIsNone(pattern.search(text))
 
     def test_skill_exposes_current_version_for_agents(self) -> None:
         metadata_version = re.search(r"version:\s*\"(\d+\.\d+\.\d+)\"", self.skill_text)

--- a/harmony-next/tests/test_ux_audit_pipeline.py
+++ b/harmony-next/tests/test_ux_audit_pipeline.py
@@ -380,7 +380,7 @@ class UxAuditPipelineTests(unittest.TestCase):
         self.assertIn("uxPythonDependencies", payload["missingConfig"])
         self.assertEqual(payload["missingModule"], "definitely_missing_ux_dependency")
         self.assertTrue(any("hdc list targets -v" in item for item in payload["recommendations"]))
-        self.assertIn("ISSUE_GUIDE.md", payload["feedback"]["issueGuide"])
+        self.assertEqual(payload["feedback"]["issueGuide"], "$HARMONY_NEXT_SKILL_DIR/ISSUE_GUIDE.md")
 
     def test_explicit_missing_ux_service_root_does_not_fall_back_to_default_app(self) -> None:
         evidence_summary = self.write_evidence_bundle(self.root / "evidence")


### PR DESCRIPTION
Fixes #27.

SKILL.md listed `$REPO_ROOT/.agents/skills/harmony-next` as an official Codex scan location, then told agents to run repo-root commands such as `harmony-next/references/...` and `python3 harmony-next/scripts/hvd_manager.py`. That relative prefix does not exist for the documented install layout.

## Before

From a repository using the standard scan-location install:

    test -e harmony-next/references/INDEX.md   # fails
    test -e .agents/skills/harmony-next/references/INDEX.md  # ok

The same mismatch broke documented `hvd_manager.py` examples.

## After

Agents resolve `HARMONY_NEXT_SKILL_DIR` from the loaded SKILL.md and run commands against that directory. Those paths work from a normal application repository root for `.agents/skills/harmony-next`, `$HOME/.agents/skills/harmony-next`, and this repository's `harmony-next/` checkout.

`hvd_manager.py` diagnostic follow-up commands now use the script's own path instead of a hardcoded `harmony-next/scripts/...` prefix.

## Test plan

- [x] python3 -m unittest harmony-next.tests.test_skill_metadata harmony-next.tests.test_hvd_manager — 49 tests passed
- [x] Simulated `.agents/skills/harmony-next` layout: repo-root `harmony-next/references/INDEX.md` is missing; `$HARMONY_NEXT_SKILL_DIR` paths exist and hvd_manager.py --help runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic, testing, and command-line workflows for skills installed or loaded from different directories.
  * Resolved scripts, references, templates, and feedback guides from the skill’s actual location.
  * Updated timeout diagnostics to invoke the correct script path.

* **Documentation**
  * Updated setup guides, command examples, and playbooks to use the resolved skill directory.

* **Tests**
  * Added coverage for installed skill layouts, path resolution, diagnostic commands, and prevention of incorrect repository-root references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->